### PR TITLE
Remove training calendar templates

### DIFF
--- a/TrainerApp/TrainerApp/Managers/TrainingScheduleManager.swift
+++ b/TrainerApp/TrainerApp/Managers/TrainingScheduleManager.swift
@@ -218,14 +218,10 @@ class TrainingScheduleManager: ObservableObject {
                     days.append(savedDay)
                     print("📥 Loaded saved workout for \(workoutStore.dateKey(for: dayDate))")
                 } else {
-                    // Apply workout template if available
-                    let workoutDay = createWorkoutDayWithTemplate(date: dayDate, blockType: targetBlock.type)
+                    // Create blank workout day
+                    let workoutDay = WorkoutDay(date: dayDate, blockType: targetBlock.type)
                     days.append(workoutDay)
-                    if workoutDay.isTemplateGenerated {
-                        print("📝 DEBUG: Created workout day with template for \(workoutDay.dayOfWeek.name)")
-                    } else {
-                        print("📭 DEBUG: No template found, created blank day")
-                    }
+                    print("📭 Created blank workout day for \(workoutDay.dayOfWeek.name)")
                 }
             }
         }
@@ -254,14 +250,10 @@ class TrainingScheduleManager: ObservableObject {
                     days.append(savedDay)
                     print("✅ generateMonth - Preserved saved workout with icon: \(savedDay.workoutIcon ?? "none")")
                 } else {
-                    // Apply workout template if available
-                    let workoutDay = createWorkoutDayWithTemplate(date: currentDate, blockType: block.type)
+                    // Create blank workout day
+                    let workoutDay = WorkoutDay(date: currentDate, blockType: block.type)
                     days.append(workoutDay)
-                    if workoutDay.isTemplateGenerated {
-                        print("📝 generateMonth - Created workout day with template")
-                    } else {
-                        print("📭 generateMonth - Created blank workout day")
-                    }
+                    print("📭 generateMonth - Created blank workout day")
                 }
             }
             
@@ -270,26 +262,6 @@ class TrainingScheduleManager: ObservableObject {
         
         print("⚠️ DEBUG generateMonth - Returning \(days.count) days")
         return days
-    }
-    
-    // MARK: - Template Application
-    
-    /// Create a WorkoutDay with template applied if available
-    private func createWorkoutDayWithTemplate(date: Date, blockType: BlockType) -> WorkoutDay {
-        let dayOfWeek = DayOfWeek.from(date: date)
-        
-        // Get template for this block + day combination
-        guard let blockTemplate = TrainingBlockTemplate.template(for: blockType),
-              let workoutTemplate = blockTemplate.templateForDay(dayOfWeek) else {
-            // Fallback to blank workout day if no template available
-            print("📭 No template found for \(blockType.rawValue) on \(dayOfWeek.name)")
-            return WorkoutDay(date: date, blockType: blockType)
-        }
-        
-        // Create WorkoutDay with template applied
-        let workoutDay = WorkoutDay.withTemplate(date: date, blockType: blockType, template: workoutTemplate)
-        print("📝 Applied template '\(workoutTemplate.title)' for \(dayOfWeek.name)")
-        return workoutDay
     }
     
     // MARK: - Helper Methods
@@ -455,7 +427,7 @@ class TrainingScheduleManager: ObservableObject {
             weekNumber: 1
         )
         
-        return createWorkoutDayWithTemplate(date: date, blockType: targetBlock.type)
+        return WorkoutDay(date: date, blockType: targetBlock.type)
     }
     
     // MARK: - Single Workout APIs

--- a/TrainerApp/TrainerApp/Models/TrainingCalendar.swift
+++ b/TrainerApp/TrainerApp/Models/TrainingCalendar.swift
@@ -1,330 +1,5 @@
 import Foundation
 
-/// Categorizes the primary type of workout session
-enum WorkoutSessionType: String, CaseIterable, Codable {
-    case strength = "Strength"
-    case cardio = "Cardio"
-    case mobility = "Mobility"
-    case rest = "Rest"
-    case mixed = "Mixed"
-    
-    var defaultIcon: String {
-        switch self {
-        case .strength:
-            return "figure.strengthtraining.traditional"
-        case .cardio:
-            return "figure.mixed.cardio"
-        case .mobility:
-            return "figure.flexibility"
-        case .rest:
-            return "bed.double.fill"
-        case .mixed:
-            return "figure.mixed.cardio"
-        }
-    }
-}
-
-/// Represents a template for a specific workout type within a training block
-struct WorkoutTemplate: Codable {
-    let title: String
-    let summary: String
-    let sessionType: WorkoutSessionType
-    let modalityPrimary: String
-    let modalitySecondary: String?
-    let focus: String
-    let durationMinutes: Int?
-    let intensityZone: String?
-    let icon: String
-    let notes: String?
-}
-
-/// Defines the weekly workout template for a specific training block type
-struct TrainingBlockTemplate: Codable {
-    let blockType: BlockType
-    let weeklyTemplate: [DayOfWeek: WorkoutTemplate]
-    
-    /// Get the workout template for a specific day
-    func templateForDay(_ day: DayOfWeek) -> WorkoutTemplate? {
-        return weeklyTemplate[day]
-    }
-    
-    /// Get template for a specific block type
-    static func template(for blockType: BlockType) -> TrainingBlockTemplate? {
-        return templates[blockType]
-    }
-    
-    /// Static templates for all training block types
-    static let templates: [BlockType: TrainingBlockTemplate] = [
-        .hypertrophyStrength: TrainingBlockTemplate(
-            blockType: .hypertrophyStrength,
-            weeklyTemplate: [
-                .monday: WorkoutTemplate(
-                    title: "Rest Day",
-                    summary: "Mobility + core (15–25′)",
-                    sessionType: .mobility,
-                    modalityPrimary: "mobility",
-                    modalitySecondary: nil,
-                    focus: "Tissue quality, hips/thoracic",
-                    durationMinutes: 20,
-                    intensityZone: "Recovery",
-                    icon: "figure.flexibility",
-                    notes: "Focus on hip and thoracic spine mobility"
-                ),
-                .tuesday: WorkoutTemplate(
-                    title: "Strength - Lower + Z2",
-                    summary: "Strength – Lower (squat/hinge) → 30–40′ Z2 bike or erg",
-                    sessionType: .mixed,
-                    modalityPrimary: "strength",
-                    modalitySecondary: "bike",
-                    focus: "Hypertrophy (legs); easy aerobic",
-                    durationMinutes: 90,
-                    intensityZone: "Strength + Z2",
-                    icon: "figure.strengthtraining.traditional",
-                    notes: "Squat/hinge movements followed by easy aerobic work"
-                ),
-                .wednesday: WorkoutTemplate(
-                    title: "RowErg Z2 + Technique",
-                    summary: "40–60′ RowErg Z2 @18–20 spm + 10′ technique drills",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: nil,
-                    focus: "Technique, capillary base",
-                    durationMinutes: 60,
-                    intensityZone: "Z2",
-                    icon: "figure.rower",
-                    notes: "Focus on stroke rate consistency and technique drills"
-                ),
-                .thursday: WorkoutTemplate(
-                    title: "Strength - Upper + Z2",
-                    summary: "Strength – Upper (press/pull) → 30–40′ Z2 spin",
-                    sessionType: .mixed,
-                    modalityPrimary: "strength",
-                    modalitySecondary: "bike",
-                    focus: "Hypertrophy (upper); easy aerobic",
-                    durationMinutes: 90,
-                    intensityZone: "Strength + Z2",
-                    icon: "figure.strengthtraining.traditional",
-                    notes: "Press/pull movements followed by easy spin"
-                ),
-                .friday: WorkoutTemplate(
-                    title: "Long RowErg Z2",
-                    summary: "60–90′ RowErg Z2 (occasional 10×10″ power strokes, full recovery)",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: nil,
-                    focus: "Aerobic base + stroke power touches",
-                    durationMinutes: 75,
-                    intensityZone: "Z2",
-                    icon: "figure.rower",
-                    notes: "Steady state with occasional power stroke touches"
-                ),
-                .saturday: WorkoutTemplate(
-                    title: "Strength - Full Body + Optional Spin",
-                    summary: "Strength – Full Body/Posterior (RDL/row/pull-ups) ± PM 30–45′ spin Z1–Z2",
-                    sessionType: .mixed,
-                    modalityPrimary: "strength",
-                    modalitySecondary: "bike",
-                    focus: "Third hypertrophy hit; optional flush",
-                    durationMinutes: 90,
-                    intensityZone: "Strength + Z1-Z2",
-                    icon: "figure.strengthtraining.traditional",
-                    notes: "Full body emphasis on posterior chain"
-                ),
-                .sunday: WorkoutTemplate(
-                    title: "Long Aerobic",
-                    summary: "75–120′ RowErg Z2 or 60–90′ run/walk-run (incline treadmill ok)",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: "run",
-                    focus: "Long aerobic steady",
-                    durationMinutes: 90,
-                    intensityZone: "Z2",
-                    icon: "figure.rower",
-                    notes: "Choose modality based on preference and back comfort"
-                )
-            ]
-        ),
-        .deload: TrainingBlockTemplate(
-            blockType: .deload,
-            weeklyTemplate: [
-                .monday: WorkoutTemplate(
-                    title: "Recovery",
-                    summary: "Mobility + breathing 15–20′",
-                    sessionType: .mobility,
-                    modalityPrimary: "mobility",
-                    modalitySecondary: nil,
-                    focus: "Recovery",
-                    durationMinutes: 18,
-                    intensityZone: "Recovery",
-                    icon: "figure.flexibility",
-                    notes: "Focus on breath work and gentle movement"
-                ),
-                .tuesday: WorkoutTemplate(
-                    title: "Easy Flush",
-                    summary: "30–40′ spin/erg Z1–low Z2",
-                    sessionType: .cardio,
-                    modalityPrimary: "bike",
-                    modalitySecondary: "row",
-                    focus: "Flush",
-                    durationMinutes: 35,
-                    intensityZone: "Z1-low Z2",
-                    icon: "bicycle",
-                    notes: "Very easy effort, focus on movement quality"
-                ),
-                .wednesday: WorkoutTemplate(
-                    title: "Light Strength",
-                    summary: "Light Full-Body Strength (machines/DBs; 2×8–12, RIR 3–4)",
-                    sessionType: .strength,
-                    modalityPrimary: "strength",
-                    modalitySecondary: nil,
-                    focus: "Movement maintenance",
-                    durationMinutes: 45,
-                    intensityZone: "Light",
-                    icon: "figure.strengthtraining.traditional",
-                    notes: "Focus on movement patterns, not load"
-                ),
-                .thursday: WorkoutTemplate(
-                    title: "Technique Focus",
-                    summary: "30–45′ erg technique (pick drills, pauses)",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: nil,
-                    focus: "Skill",
-                    durationMinutes: 38,
-                    intensityZone: "Z1",
-                    icon: "figure.rower",
-                    notes: "Emphasis on stroke mechanics and drills"
-                ),
-                .friday: WorkoutTemplate(
-                    title: "Base Maintenance",
-                    summary: "40–60′ spin/erg Z2",
-                    sessionType: .cardio,
-                    modalityPrimary: "bike",
-                    modalitySecondary: "row",
-                    focus: "Base",
-                    durationMinutes: 50,
-                    intensityZone: "Z2",
-                    icon: "bicycle",
-                    notes: "Comfortable aerobic effort"
-                ),
-                .saturday: WorkoutTemplate(
-                    title: "Easy Movement",
-                    summary: "30–40′ walk/run or spin + mobility",
-                    sessionType: .mixed,
-                    modalityPrimary: "run",
-                    modalitySecondary: "bike",
-                    focus: "Easy",
-                    durationMinutes: 35,
-                    intensityZone: "Z1",
-                    icon: "figure.run",
-                    notes: "Very gentle movement plus stretching"
-                ),
-                .sunday: WorkoutTemplate(
-                    title: "Absorb",
-                    summary: "Off or 30–40′ Z1 + mobility",
-                    sessionType: .rest,
-                    modalityPrimary: "mobility",
-                    modalitySecondary: nil,
-                    focus: "Absorb",
-                    durationMinutes: 35,
-                    intensityZone: "Z1 or Rest",
-                    icon: "bed.double.fill",
-                    notes: "Complete rest or very gentle movement"
-                )
-            ]
-        ),
-        .aerobicCapacity: TrainingBlockTemplate(
-            blockType: .aerobicCapacity,
-            weeklyTemplate: [
-                .monday: WorkoutTemplate(
-                    title: "Prep",
-                    summary: "Mobility + core 15–20′",
-                    sessionType: .mobility,
-                    modalityPrimary: "mobility",
-                    modalitySecondary: nil,
-                    focus: "Prep tissues",
-                    durationMinutes: 18,
-                    intensityZone: "Recovery",
-                    icon: "figure.flexibility",
-                    notes: "Prepare body for higher intensity week"
-                ),
-                .tuesday: WorkoutTemplate(
-                    title: "Base + Power Strides",
-                    summary: "60–90′ RowErg Z2 with 8–12×20″ @ Z3/UT1, 100″ easy",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: nil,
-                    focus: "Aerobic base + aerobic power strides",
-                    durationMinutes: 75,
-                    intensityZone: "Z2 + Z3/UT1",
-                    icon: "figure.rower",
-                    notes: "Steady base with short power touches"
-                ),
-                .wednesday: WorkoutTemplate(
-                    title: "Strength Maintenance",
-                    summary: "Strength – Full Body (Maintenance) 45–60′ (2–3×5–8 main, RIR 2) ± 15–20′ easy spin",
-                    sessionType: .mixed,
-                    modalityPrimary: "strength",
-                    modalitySecondary: "bike",
-                    focus: "Strength maintenance",
-                    durationMinutes: 75,
-                    intensityZone: "Maintenance + Z1",
-                    icon: "figure.strengthtraining.traditional",
-                    notes: "Maintain strength with reduced volume"
-                ),
-                .thursday: WorkoutTemplate(
-                    title: "Threshold",
-                    summary: "Threshold on erg (e.g., 3×12′ @ AT / 10k effort, 3′ easy) or 35–50′ steady tempo",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: nil,
-                    focus: "Raise LT/AT",
-                    durationMinutes: 60,
-                    intensityZone: "AT/Threshold",
-                    icon: "figure.rower",
-                    notes: "Lactate threshold focused intervals"
-                ),
-                .friday: WorkoutTemplate(
-                    title: "Volume",
-                    summary: "75–120′ RowErg Z2 @ 18–20 spm (no surges)",
-                    sessionType: .cardio,
-                    modalityPrimary: "row",
-                    modalitySecondary: nil,
-                    focus: "Volume",
-                    durationMinutes: 95,
-                    intensityZone: "Z2",
-                    icon: "figure.rower",
-                    notes: "Steady volume work at controlled stroke rate"
-                ),
-                .saturday: WorkoutTemplate(
-                    title: "VO₂ / High-UT1",
-                    summary: "VO₂ / High-UT1 on erg (e.g., 5–6×4′ @ ~5k pace, 3′ easy) ± PM 30–45′ Z1 spin",
-                    sessionType: .mixed,
-                    modalityPrimary: "row",
-                    modalitySecondary: "bike",
-                    focus: "Top-end aerobic",
-                    durationMinutes: 90,
-                    intensityZone: "VO₂/High-UT1 + Z1",
-                    icon: "figure.rower",
-                    notes: "High intensity aerobic power development"
-                ),
-                .sunday: WorkoutTemplate(
-                    title: "Long Cross-Training",
-                    summary: "90–150′ bike Z2 or 75–120′ erg Z2; alternate modality weekly",
-                    sessionType: .cardio,
-                    modalityPrimary: "bike",
-                    modalitySecondary: "row",
-                    focus: "Long aerobic, joint-friendly",
-                    durationMinutes: 120,
-                    intensityZone: "Z2",
-                    icon: "bicycle",
-                    notes: "Alternate between bike and erg weekly for joint health"
-                )
-            ]
-        )
-    ]
-}
-
 /// Days of the week for workout scheduling
 enum DayOfWeek: Int, CaseIterable, Codable {
     case monday = 1
@@ -388,15 +63,11 @@ struct WorkoutDay: Codable, Identifiable {
     let dayOfWeek: DayOfWeek
     let blockType: BlockType
     var plannedWorkout: String?  // Legacy field - kept for backward compatibility, read-only
-    var isCoachPlanned: Bool = false  // Track if coach-generated vs template
+    var isCoachPlanned: Bool = false  // Track if coach-generated
     var workoutIcon: String?  // Coach-selected icon (SF Symbol name)
     
-    // NEW: Structured workout data
+    // Structured workout data
     var structuredWorkout: StructuredWorkout?
-    
-    // NEW: Template tracking
-    var isTemplateGenerated: Bool = false  // Track if generated from template
-    var templateType: WorkoutSessionType?  // Type of template used
     
     init(date: Date, blockType: BlockType, plannedWorkout: String? = nil) {
         self.date = date
@@ -417,54 +88,9 @@ struct WorkoutDay: Codable, Identifiable {
         }
     }
     
-    /// Create a WorkoutDay with template-generated content
-    static func withTemplate(date: Date, blockType: BlockType, template: WorkoutTemplate) -> WorkoutDay {
-        var workoutDay = WorkoutDay(date: date, blockType: blockType)
-        workoutDay.applyTemplate(template)
-        return workoutDay
-    }
-    
-    /// Apply a workout template to this day
-    mutating func applyTemplate(_ template: WorkoutTemplate) {
-        self.isTemplateGenerated = true
-        self.templateType = template.sessionType
-        self.workoutIcon = template.icon
-        self.isCoachPlanned = false // Template-generated, not coach-planned
-        
-        // Create a skeleton StructuredWorkout from the template
-        self.structuredWorkout = createStructuredWorkoutFromTemplate(template)
-    }
-    
-    /// Create a StructuredWorkout from a template (placeholder for coach to customize)
-    private func createStructuredWorkoutFromTemplate(_ template: WorkoutTemplate) -> StructuredWorkout {
-        let placeholderExercise = Exercise(
-            kind: template.modalityPrimary,
-            name: template.summary,
-            focus: template.focus,
-            equipment: nil,
-            tags: nil,
-            detail: .generic(GenericDetail(
-                items: ["Template: \(template.focus)"],
-                notes: template.notes
-            ))
-        )
-        
-        return StructuredWorkout(
-            title: template.title,
-            summary: template.summary,
-            durationMinutes: template.durationMinutes,
-            notes: template.notes,
-            exercises: [placeholderExercise]
-        )
-    }
-    
-    /// Check if this day has any workout content (structured, legacy, or template)
+    /// Check if this day has any workout content (structured or legacy)
     var hasWorkout: Bool {
-        let result = structuredWorkout != nil || plannedWorkout != nil || isTemplateGenerated
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        print("🔍 hasWorkout DEBUG: \(dayOfWeek.name) \(formatter.string(from: date)) - plannedWorkout: \(plannedWorkout != nil), structuredWorkout: \(structuredWorkout != nil), isTemplateGenerated: \(isTemplateGenerated), hasWorkout: \(result)")
-        return result
+        return structuredWorkout != nil || plannedWorkout != nil
     }
     
     /// Get the display icon for this workout day
@@ -479,16 +105,11 @@ struct WorkoutDay: Codable, Identifiable {
             return structured.derivedIcon
         }
         
-        // Priority 3: Template type default icon
-        if isTemplateGenerated, let templateType = templateType {
-            return templateType.defaultIcon
-        }
-        
-        // Priority 4: No workout indicator
+        // Priority 3: No workout indicator
         return WorkoutType.noWorkout.icon
     }
     
-    /// Get a summary for display (structured takes priority, then legacy, then template)
+    /// Get a summary for display (structured takes priority, then legacy)
     var displaySummary: String? {
         if let structured = structuredWorkout {
             return structured.displaySummary
@@ -498,24 +119,18 @@ struct WorkoutDay: Codable, Identifiable {
             return planned
         }
         
-        if isTemplateGenerated, let templateType = templateType {
-            return "Template: \(templateType.rawValue)"
-        }
-        
         return nil
     }
     
-    /// Check if this is a coach-customized workout (vs template or blank)
+    /// Check if this is a coach-customized workout (vs blank)
     var isCoachCustomized: Bool {
-        return isCoachPlanned || (structuredWorkout != nil && !isTemplateGenerated)
+        return isCoachPlanned || structuredWorkout != nil
     }
     
     /// Get the workout status for UI display
     var workoutStatus: WorkoutStatus {
         if isCoachCustomized {
             return .coachPlanned
-        } else if isTemplateGenerated {
-            return .templateGenerated
         } else {
             return .blank
         }
@@ -525,15 +140,12 @@ struct WorkoutDay: Codable, Identifiable {
 /// Represents the status of a workout day for UI purposes
 enum WorkoutStatus: String, CaseIterable {
     case blank = "Blank"
-    case templateGenerated = "Template"
     case coachPlanned = "Coach Planned"
     
     var icon: String {
         switch self {
         case .blank:
             return "calendar.badge.exclamationmark"
-        case .templateGenerated:
-            return "doc.text"
         case .coachPlanned:
             return "checkmark.circle.fill"
         }
@@ -543,8 +155,6 @@ enum WorkoutStatus: String, CaseIterable {
         switch self {
         case .blank:
             return "gray"
-        case .templateGenerated:
-            return "blue"
         case .coachPlanned:
             return "green"
         }


### PR DESCRIPTION
## Summary
Removes the pre-populated training calendar template system. The schedule now starts completely blank until the coach explicitly plans workouts via tool calls.

## Changes
- **Removed WorkoutSessionType enum, WorkoutTemplate struct, and TrainingBlockTemplate struct** (~325 lines)
  - Deleted all static templates for hypertrophyStrength, deload, and aerobicCapacity blocks
- **Removed template-related fields from WorkoutDay**
  - `isTemplateGenerated` field
  - `templateType` field
- **Removed template-related methods**
  - `withTemplate()` static factory method
  - `applyTemplate()` method
  - `createStructuredWorkoutFromTemplate()` method
- **Simplified WorkoutDay computed properties**
  - `hasWorkout` - removed template check
  - `displayIcon` - removed template fallback
  - `displaySummary` - removed template fallback
  - `isCoachCustomized` - removed template check
  - `workoutStatus` - removed template case
- **Updated WorkoutStatus enum**
  - Removed `templateGenerated` case (now only `blank` and `coachPlanned`)
- **Simplified TrainingScheduleManager**
  - Removed `createWorkoutDayWithTemplate()` method
  - Updated `generateWeek()` to always create blank WorkoutDay objects
  - Updated `generateMonth()` to always create blank WorkoutDay objects
  - Updated `generateDayForDate()` to return blank WorkoutDay objects

## Impact
- **Total code reduction**: ~350+ lines
- **Build status**: ✅ Builds successfully with no compilation errors
- **Backward compatibility**: Existing persisted data with template fields will be gracefully ignored by Swift's Codable

## Result
The app now follows a cleaner model where all workouts are explicitly planned by the coach via tool calls, providing a clearer user experience with no pre-populated template content that could be misleading.