### PR TITLE
Add swimming, crossTraining, and testing modalities to Exercise API

### DIFF
--- a/TrainerApp/TrainerApp/Models/ExerciseAPIModels.swift
+++ b/TrainerApp/TrainerApp/Models/ExerciseAPIModels.swift
@@ -11,6 +11,9 @@ enum APIDayPrimaryModality: String, Codable {
     case mobility
     case hiking
     case rest
+    case swimming      // Pool or open water workouts
+    case crossTraining // Mixed-modality training
+    case testing       // Fitness assessment (VO2max, FTP, etc.)
 }
 
 /// Cardio modality types

--- a/TrainerApp/TrainerApp/Services/WorkoutToAPIMapper.swift
+++ b/TrainerApp/TrainerApp/Services/WorkoutToAPIMapper.swift
@@ -92,7 +92,7 @@ class WorkoutToAPIMapper {
         ```json
         {
             "entry": {
-                "primaryModality": "strength|rowing|spinning|running|mobility|hiking|rest",
+                "primaryModality": "strength|rowing|spinning|running|mobility|hiking|rest|swimming|crossTraining|testing",
                 "dayNotes": "string or null"
             },
             "strengthExercises": [
@@ -193,6 +193,9 @@ class WorkoutToAPIMapper {
         ### 4. Modality Detection:
            - primaryModality: main focus of the day
            - cardio modality: "row*" → "rowing", "bike*"/"spin*" → "spinning", "run*" → "running"
+           - "swim*" → "swimming" (pool or open water workouts)
+           - "cross*"/"mixed*"/"circuit*" → "crossTraining" (mixed-modality training)
+           - "test*"/"assess*"/"FTP*"/"VO2*" → "testing" (fitness assessments)
 
         ### 5. Coach Notes:
            - coachNotes: Put the FULL prescription text from the plan here


### PR DESCRIPTION
## Summary

This PR adds support for three new `primaryModality` values in the Exercise API, per the developer notification.

## New Modalities

| Value | Description | Use Case |
|-------|-------------|----------|
| `swimming` | Pool or open water workouts | Track swim training days |
| `crossTraining` | Mixed-modality training | Non-specific cross-training sessions |
| `testing` | Fitness assessment | Assessment/testing days (VO2max, FTP, etc.) |

## Changes

### ExerciseAPIModels.swift
- Added three new cases to `APIDayPrimaryModality` enum with documentation comments

### WorkoutToAPIMapper.swift  
- Updated schema in LLM prompt to include all 10 modality values
- Added modality detection patterns:
  - `swim*` → `swimming`
  - `cross*/mixed*/circuit*` → `crossTraining`
  - `test*/assess*/FTP*/VO2*` → `testing`

## API Reference

typescript
type DayPrimaryModality = 
  | 'strength'
  | 'rowing'
  | 'spinning'
  | 'running'
  | 'mobility'
  | 'hiking'
  | 'rest'
  | 'swimming'      // NEW
  | 'crossTraining' // NEW
  | 'testing';      // NEW
```

Build verified ✅